### PR TITLE
Add argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Spell It For Me
 A simple command line tool to display a spelling for any phrase using a phonetic alphabet.
 
-Uses the NATO phonetic alphabet.
+Can use NATO (`-a nato`, active by default) or law enforcement (`-a police`) phonetic alphabets.
 
-More alphabets will be supported in the future.
+More alphabets might be supported in the future.
 
 ## Installation
 
@@ -15,8 +15,47 @@ $ pip install spell-it-for-me
 
 ## Usage
 
+By default `spell` will print every letter spelled on a separate line using the NATO phonetic alphabet:  
 ```bash
-$ spell Louis
+$ spell Louis 
+Líma
+Óscar
+Úniform
+Índia
+Siérra
+```
+
+Spelling phrases of several words is supported:
+```bash
+$ spell Worcester, MA
+Whísky
+Óscar
+Rómeo
+Chárlie
+Écho
+Siérra
+Tángo
+Écho
+Rómeo
+,
+ 
+Mike
+Álfa
+```
+
+Law enforcement alphabet is available (use `-a police` or `--alphabet police`):
+```bash
+$ spell -a police Louis
+Lincoln
+Oscar
+Union
+Ida
+Sam
+```
+
+Use `-v` (or `--verbose`) to print each letter used for spelling:
+```bash
+spell.py -v Louis
 L: Líma
 o: Óscar
 u: Úniform

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='spell-it-for-me',
-    version='0.1.1',
+    version='0.2.1',
     url='https://github.com/bondarevts/spell-it-for-me',
     author='Timofei Bondarev',
     author_email='bondarevts@gmail.com',
@@ -18,10 +18,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/src/spell.py
+++ b/src/spell.py
@@ -71,9 +71,21 @@ parser.add_argument(
     default="nato",
     choices=["nato", "police"],
     dest="alphabet",
+    help="Defaults to NATO phonetic alphabet: Álfa Brávo Chárlie..., "
+    "can also use police: Adam Boston Charles...",
 )
-parser.add_argument("--verbose", "-v", action="store_true", dest="verbose")
-parser.add_argument(dest="phrase", nargs="+")
+parser.add_argument(
+    "--verbose",
+    "-v",
+    action="store_true",
+    dest="verbose",
+    help="Print the original letter before each phonetic alphabet word",
+)
+parser.add_argument(
+    dest="phrase",
+    nargs="+",
+    help="The word or phrase you want to spell using a phonetic alphabet",
+)
 
 
 def print_spelling(args: argparse.ArgumentParser) -> None:

--- a/src/spell.py
+++ b/src/spell.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 import argparse
 
-law_enforcement_spelling = {
+police_spelling = {
     "a": "Adam",
     "b": "Boston",
     "c": "Charles",
@@ -67,23 +67,26 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument(
     "--alphabet",
+    "-a",
     default="nato",
-    choices=["nato", "law_enforcement"],
+    choices=["nato", "police"],
     dest="alphabet",
 )
-parser.add_argument(dest="phrase")
-parser.add_argument("--print-letter", default=1, dest="print_letter")
+parser.add_argument("--verbose", "-v", action="store_true", dest="verbose")
+parser.add_argument(dest="phrase", nargs="+")
 
 
 def print_spelling(args: argparse.ArgumentParser) -> None:
     if args.alphabet == "nato":
         spelling_map = nato_spelling
-    elif args.alphabet == "law_enforcement":
-        spelling_map = law_enforcement_spelling
+    elif args.alphabet == "police":
+        spelling_map = police_spelling
     else:
         raise ValueError(f"Improper alphabet arg, must be {args.alphabet.choices}")
-    for letter in args.phrase:
-        if args.print_letter == 1:
+    for letter in " ".join(args.phrase):
+        if not spelling_map.get(letter.lower(), False):
+            continue
+        if args.verbose:
             print(letter, ": ", sep="", end="")
         print(spelling_map.get(letter.lower(), letter))
 

--- a/src/spell.py
+++ b/src/spell.py
@@ -2,77 +2,98 @@
 from __future__ import print_function
 
 import sys
+import argparse
 from typing import Dict
 
 law_enforcement_spelling = {
-    'a': 'Adam',
-    'b': 'Boston',
-    'c': 'Charles',
-    'd': 'David',
-    'e': 'Edward',
-    'f': 'Frank',
-    'g': 'George',
-    'h': 'Henry',
-    'i': 'Ida',
-    'j': 'James',
-    'k': 'King',
-    'l': 'Lincoln',
-    'm': 'Mary',
-    'n': 'Nora',
-    'o': 'Oscar',
-    'p': 'Paul',
-    'q': 'Queen',
-    'r': 'Robert',
-    's': 'Sam',
-    't': 'Tom',
-    'u': 'Union',
-    'v': 'Victor',
-    'w': 'William',
-    'x': 'X-Ray',
-    'y': 'Young',
-    'z': 'Zebra',
+    "a": "Adam",
+    "b": "Boston",
+    "c": "Charles",
+    "d": "David",
+    "e": "Edward",
+    "f": "Frank",
+    "g": "George",
+    "h": "Henry",
+    "i": "Ida",
+    "j": "James",
+    "k": "King",
+    "l": "Lincoln",
+    "m": "Mary",
+    "n": "Nora",
+    "o": "Oscar",
+    "p": "Paul",
+    "q": "Queen",
+    "r": "Robert",
+    "s": "Sam",
+    "t": "Tom",
+    "u": "Union",
+    "v": "Victor",
+    "w": "William",
+    "x": "X-Ray",
+    "y": "Young",
+    "z": "Zebra",
 }
 
 nato_spelling = {
-    'a': 'Álfa',
-    'b': 'Brávo',
-    'c': 'Chárlie',
-    'd': 'Délta',
-    'e': 'Écho',
-    'f': 'Fóxtrot',
-    'g': 'Gólf',
-    'h': 'Hotél',
-    'i': 'Índia',
-    'j': 'Júliett',
-    'k': 'Kílo',
-    'l': 'Líma',
-    'm': 'Mike',
-    'n': 'Novémber',
-    'o': 'Óscar',
-    'p': 'Papá',
-    'q': 'Quebéc',
-    'r': 'Rómeo',
-    's': 'Siérra',
-    't': 'Tángo',
-    'u': 'Úniform',
-    'v': 'Víctor',
-    'w': 'Whísky',
-    'x': 'X-ray',
-    'y': 'Yánkee',
-    'z': 'Zúlu'
+    "a": "Álfa",
+    "b": "Brávo",
+    "c": "Chárlie",
+    "d": "Délta",
+    "e": "Écho",
+    "f": "Fóxtrot",
+    "g": "Gólf",
+    "h": "Hotél",
+    "i": "Índia",
+    "j": "Júliett",
+    "k": "Kílo",
+    "l": "Líma",
+    "m": "Mike",
+    "n": "Novémber",
+    "o": "Óscar",
+    "p": "Papá",
+    "q": "Quebéc",
+    "r": "Rómeo",
+    "s": "Siérra",
+    "t": "Tángo",
+    "u": "Úniform",
+    "v": "Víctor",
+    "w": "Whísky",
+    "x": "X-ray",
+    "y": "Yánkee",
+    "z": "Zúlu",
 }
 
+parser = argparse.ArgumentParser(
+    description="A simple command line tool "
+    "to display a spelling for any phrase "
+    "using a phonetic alphabet."
+)
+parser.add_argument(
+    "--alphabet",
+    default="nato",
+    choices=["nato", "law_enforcement"],
+    dest="alphabet",
 
-def print_spelling(word: str, spelling_map: Dict[str, str]) -> None:
-    for letter in word:
-        print(letter, ': ', sep='', end='')
+)
+parser.add_argument(dest="phrase")
+
+
+def print_spelling(args: argparse.ArgumentParser) -> None:
+    if args.alphabet == "nato":
+        spelling_map = nato_spelling
+    elif args.alphabet == "law_enforcement":
+        spelling_map = law_enforcement_spelling
+    else:
+        raise ValueError(f"Improper alphabet arg, must be {args['alphabet'].choices}")
+    for letter in args.phrase:
+        print(letter, ": ", sep="", end="")
         print(spelling_map.get(letter.lower(), letter))
 
 
 def main() -> None:
-    phrase = ' '.join(sys.argv[1:])
-    print_spelling(phrase, nato_spelling)
+    args = parser.parse_args()
+    print_spelling(args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/spell.py
+++ b/src/spell.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
-
-import sys
 import argparse
-from typing import Dict
 
 law_enforcement_spelling = {
     "a": "Adam",
@@ -73,9 +70,9 @@ parser.add_argument(
     default="nato",
     choices=["nato", "law_enforcement"],
     dest="alphabet",
-
 )
 parser.add_argument(dest="phrase")
+parser.add_argument("--print-letter", default=1, dest="print_letter")
 
 
 def print_spelling(args: argparse.ArgumentParser) -> None:
@@ -84,9 +81,10 @@ def print_spelling(args: argparse.ArgumentParser) -> None:
     elif args.alphabet == "law_enforcement":
         spelling_map = law_enforcement_spelling
     else:
-        raise ValueError(f"Improper alphabet arg, must be {args['alphabet'].choices}")
+        raise ValueError(f"Improper alphabet arg, must be {args.alphabet.choices}")
     for letter in args.phrase:
-        print(letter, ": ", sep="", end="")
+        if args.print_letter == 1:
+            print(letter, ": ", sep="", end="")
         print(spelling_map.get(letter.lower(), letter))
 
 

--- a/src/spell.py
+++ b/src/spell.py
@@ -96,8 +96,6 @@ def print_spelling(args: argparse.ArgumentParser) -> None:
     else:
         raise ValueError(f"Improper alphabet arg, must be {args.alphabet.choices}")
     for letter in " ".join(args.phrase):
-        if not spelling_map.get(letter.lower(), False):
-            continue
         if args.verbose:
             print(letter, ": ", sep="", end="")
         print(spelling_map.get(letter.lower(), letter))


### PR DESCRIPTION
I wanted the option to pipe the words to a text-to-speech program, e.g. on MacOS: `python src/spell.py --print-letter=0 WTF | say`. This required adding the option to turn off the original letter in the output, and while I was there, I added the option to pick which alphabet dict you want to use.